### PR TITLE
Fix product thumbnail cropping

### DIFF
--- a/storefront/src/modules/products/components/product-preview/index.tsx
+++ b/storefront/src/modules/products/components/product-preview/index.tsx
@@ -33,7 +33,7 @@ export default async function ProductPreview({
         data-testid="product-wrapper"
         className="flex flex-col gap-4 relative aspect-[3/5] w-full overflow-hidden p-4 bg-white shadow-borders-base rounded-lg group-hover:shadow-[0_0_0_4px_rgba(0,0,0,0.1)] transition-shadow ease-in-out duration-150"
       >
-        <div className="w-full h-full p-10">
+        <div className="w-full h-full">
           <Thumbnail
             thumbnail={product.thumbnail}
             images={product.images}

--- a/storefront/src/modules/products/components/thumbnail/index.tsx
+++ b/storefront/src/modules/products/components/thumbnail/index.tsx
@@ -55,7 +55,7 @@ const ImageOrPlaceholder = ({
     <Image
       src={image}
       alt="Thumbnail"
-      className={clx("absolute inset-0 object-contain", {
+      className={clx("absolute inset-0 object-cover object-center", {
         "p-4": type === "full",
         "p-2": type === "preview",
       })}


### PR DESCRIPTION
## Summary
- adjust thumbnail component to use object-cover
- remove extra padding from product previews

## Testing
- `yarn install` *(fails: peer dependency warnings)*
- `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=demo yarn lint` *(fails: rule load error)*

------
https://chatgpt.com/codex/tasks/task_e_685f4779bb4483248a0a56cb0ca0175b